### PR TITLE
Use physical cores for VBox configuration.

### DIFF
--- a/private/Vagrantfile
+++ b/private/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     # Give VM 1/4 system memory & access to all cpu cores on the host
     if host =~ /darwin/
-      cpus = `sysctl -n hw.ncpu`.to_i
+      cpus = `sysctl -n machdep.cpu.core_count`.to_i
       # sysctl returns Bytes and we need to convert to MB
       mem = `sysctl -n hw.memsize`.to_i / 1024 / 1024 / 4
     elsif host =~ /linux/


### PR DESCRIPTION
Fix VirtualBox prompting you that you are using more Processors than are physically in your computer. We already did this on linux, in OS X this is accomplished by using `sysctl -n machdep.cpu.core_count` rather than `sysctl -n hw.ncpu`
![](http://ss.n-n.moe/OaT1yTOVGK.png)