### PR TITLE
Name VMs created with template.

### DIFF
--- a/private/Vagrantfile
+++ b/private/Vagrantfile
@@ -25,6 +25,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
     host = RbConfig::CONFIG['host_os']
 
+    v.name = settings['name']
+
     # Give VM 1/4 system memory & access to all cpu cores on the host
     if host =~ /darwin/
       cpus = `sysctl -n machdep.cpu.core_count`.to_i

--- a/private/example.config.yml
+++ b/private/example.config.yml
@@ -3,5 +3,6 @@
 # Copy this file to config.yml and change as needed.
 #
 ---
+name: example_dev
 hostname: local.example.com
 ip: 192.168.10.10


### PR DESCRIPTION
This will help with the hundreds of Vagrant boxes on your systems just named "default".